### PR TITLE
feat: integrate QC tools (FastQC, Picard, samtools, Qualimap, MultiQC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ flowchart LR
     DEDUP["GATK\nMarkDuplicates"]
     BQSR["GATK\nBQSR"]
     BAM["Analysis-ready\nBAM"]
+    FASTQC["FastQC"]
+    QC["samtools stats\nPicard metrics\nQualimap"]
+    MULTIQC["MultiQC\nreport"]
 
     FASTQ --> TRIM
     TRIM -.->|trimming\nenabled| ALIGN
@@ -21,8 +24,16 @@ flowchart LR
     MERGE --> DEDUP
     DEDUP --> BQSR
     BQSR --> BAM
+    FASTQ -.-> FASTQC
+    BAM -.-> QC
+    FASTQC -.-> MULTIQC
+    QC -.-> MULTIQC
+    DEDUP -.->|dedup\nmetrics| MULTIQC
 
     style TRIM stroke-dasharray: 5 5
+    style FASTQC stroke-dasharray: 5 5
+    style QC stroke-dasharray: 5 5
+    style MULTIQC stroke-dasharray: 5 5
 ```
 
 ---
@@ -223,6 +234,7 @@ tail -f slurm_logs/slurm-*.log
 | `ref` | `genome`, `build`, `known_sites` (list of VCFs for BQSR) |
 | `paths` | `fastq_folder`, `output_folder`, `samples` (path to TSV) |
 | `trimming` | Set `enabled: true` to run BBDuk adapter trimming before alignment |
+| `qc` | Quality control: `enabled`, per-tool toggles (`fastqc`, `samtools_stats`, `samtools_flagstat`, `picard_collect_metrics`, `qualimap`) |
 | `params` | Extra CLI flags passed through to bwa, samtools, GATK tools |
 | `subset` | Optional BAM subsetting by BED regions |
 
@@ -267,9 +279,12 @@ Cluster-specific SLURM executor plugin settings. Used automatically when the lau
 
 | Conda env | Tools | Used by |
 |---|---|---|
-| `workflow/envs/bwa_samtools.yaml` | bwa 0.7.18, samtools 1.21, samblaster 0.1.26 | alignment, merge, utilities |
-| `workflow/envs/gatk.yaml` | gatk4 4.6.1.0, samtools 1.21 | dedup, BQSR |
+| `workflow/envs/bwa_samtools.yaml` | bwa 0.7.18, samtools 1.21, samblaster 0.1.26 | alignment, merge, utilities, samtools QC |
+| `workflow/envs/gatk.yaml` | gatk4 4.6.1.0, samtools 1.21 | dedup, BQSR, Picard metrics |
 | `workflow/envs/bbtools.yaml` | bbmap 39.06 | trimming |
+| `workflow/envs/fastqc.yaml` | fastqc 0.12.1 | FASTQ quality control |
+| `workflow/envs/multiqc.yaml` | multiqc 1.33 | QC report aggregation |
+| `workflow/envs/qualimap.yaml` | qualimap 2.3 | alignment coverage analysis (opt-in) |
 
 Conda environments are created automatically by Snakemake on first run (`software-deployment-method: conda` in the workflow profile).
 
@@ -299,6 +314,51 @@ Then comment out `software-deployment-method` in `profiles/default/config.yaml` 
 
 ```bash
 sbatch scripts/run_snakemake.sh workflow/Snakefile config/config.yaml --sdm none
+```
+
+---
+
+## Quality Control
+
+QC runs automatically alongside the main pipeline (controlled by `qc.enabled` in config). The final output is a single MultiQC HTML report aggregating all metrics.
+
+### What gets collected
+
+| Tool | Runs on | Metrics |
+|------|---------|---------|
+| **FastQC** | Raw FASTQs (+ trimmed if enabled) | Per-base quality, adapter content, GC distribution, overrepresented sequences |
+| **samtools stats** | Final BAM | Error rate per cycle, base composition, insert size, indel distribution |
+| **samtools flagstat** | Final BAM | Total/mapped/paired/duplicate read counts |
+| **Picard CollectMultipleMetrics** | Final BAM | Alignment summary, insert size, GC bias, quality by cycle, sequencing artifacts |
+| **Picard MarkDuplicates** | (already produced) | Duplication rate, optical duplicates |
+| **Qualimap** (opt-in) | Final BAM | Coverage distribution, mean depth, mapping quality distribution |
+
+### Configuration
+
+```yaml
+qc:
+  enabled: true                 # master switch
+  fastqc: true                  # FastQC on FASTQs
+  samtools_stats: true          # samtools stats on final BAM
+  samtools_flagstat: true       # samtools flagstat on final BAM
+  picard_collect_metrics: true  # Picard CollectMultipleMetrics
+  qualimap: false               # opt-in (requires ~16 GB RAM on GRCh38)
+  qualimap_feature_file: ""     # BED for exome on-target stats
+```
+
+Set `qc.enabled: false` to skip all QC and produce only BAM files (pipeline behaves exactly as before).
+
+### Output
+
+```
+{output_folder}/qc/
+├── fastqc/raw/          # FastQC reports per FASTQ file
+├── fastqc/trimmed/      # (when trimming enabled)
+├── samtools/            # *.stats.txt, *.flagstat.txt
+├── picard/              # CollectMultipleMetrics output files
+├── qualimap/            # (when qc.qualimap: true)
+├── multiqc_report.html  # ← aggregated report
+└── multiqc_data/
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ flowchart LR
     DEDUP["GATK\nMarkDuplicates"]
     BQSR["GATK\nBQSR"]
     BAM["Analysis-ready\nBAM"]
-    FASTQC["FastQC"]
+    FQC_RAW["FastQC\nraw"]
+    FQC_TRIM["FastQC\ntrimmed"]
     QC["samtools stats\nPicard metrics\nQualimap"]
     MULTIQC["MultiQC\nreport"]
 
@@ -24,14 +25,18 @@ flowchart LR
     MERGE --> DEDUP
     DEDUP --> BQSR
     BQSR --> BAM
-    FASTQ -.-> FASTQC
+
+    FASTQ -.-> FQC_RAW
+    TRIM -.-> FQC_TRIM
     BAM -.-> QC
-    FASTQC -.-> MULTIQC
+    FQC_RAW -.-> MULTIQC
+    FQC_TRIM -.-> MULTIQC
     QC -.-> MULTIQC
     DEDUP -.->|dedup\nmetrics| MULTIQC
 
     style TRIM stroke-dasharray: 5 5
-    style FASTQC stroke-dasharray: 5 5
+    style FQC_RAW stroke-dasharray: 5 5
+    style FQC_TRIM stroke-dasharray: 5 5
     style QC stroke-dasharray: 5 5
     style MULTIQC stroke-dasharray: 5 5
 ```

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -74,6 +74,16 @@ trimming:
   ziplevel: 5
   quantize: "0,10,20,30,40,50,60"
 
+# --- Quality control ---
+qc:
+  enabled: true                 # master switch — set false to skip all QC
+  fastqc: true                  # FastQC on raw (+ trimmed if trimming.enabled)
+  samtools_stats: true          # samtools stats on final BAM
+  samtools_flagstat: true       # samtools flagstat on final BAM
+  picard_collect_metrics: true  # Picard CollectMultipleMetrics on final BAM
+  qualimap: false               # Qualimap bamqc — opt-in (high memory on GRCh38)
+  qualimap_feature_file: ""     # BED file for Qualimap exome on-target stats
+
 # --- Subset BAM (optional) ---
 subset:
   bed_file: ""

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -39,6 +39,14 @@ set-threads:
   subset_bam: 1
   align_and_sort: 8
   index_bam: 1
+  # QC rules
+  fastqc_raw: 1
+  fastqc_trimmed: 1
+  samtools_stats: 1
+  samtools_flagstat: 1
+  picard_collect_multiple_metrics: 1
+  qualimap_bamqc: 4
+  multiqc: 1
 
 # --- Per-rule resource overrides ---
 # cpus_per_task mirrors set-threads as a workaround for
@@ -83,4 +91,33 @@ set-resources:
   index_bam:
     mem_mb: 4000
     runtime: 120
+    cpus_per_task: 1
+  # QC rules
+  fastqc_raw:
+    mem_mb: 1024
+    runtime: 60
+    cpus_per_task: 1
+  fastqc_trimmed:
+    mem_mb: 1024
+    runtime: 60
+    cpus_per_task: 1
+  samtools_stats:
+    mem_mb: 4000
+    runtime: 120
+    cpus_per_task: 1
+  samtools_flagstat:
+    mem_mb: 2000
+    runtime: 30
+    cpus_per_task: 1
+  picard_collect_multiple_metrics:
+    mem_mb: 8000
+    runtime: 720
+    cpus_per_task: 1
+  qualimap_bamqc:
+    mem_mb: 16384
+    runtime: 720
+    cpus_per_task: 4
+  multiqc:
+    mem_mb: 4000
+    runtime: 60
     cpus_per_task: 1

--- a/tests/data/config/config.yaml
+++ b/tests/data/config/config.yaml
@@ -46,6 +46,9 @@ params:
 trimming:
   enabled: false
 
+qc:
+  enabled: true
+
 subset:
   bed_file: ""
   output_suffix: ".subset.bam"

--- a/tests/test_dryrun.py
+++ b/tests/test_dryrun.py
@@ -96,3 +96,18 @@ class TestDryRun:
         invalid_config = REPO_ROOT / "tests" / "data" / "config" / "config_invalid_build.yaml"
         result = _run_snakemake(config=invalid_config)
         assert result.returncode != 0
+
+    def test_qc_rules_listed(self):
+        """QC rules should be listed when qc.enabled is true (default)."""
+        result = _run_snakemake("--list-rules", dry_run=False)
+        assert result.returncode == 0, result.stderr
+        for rule in (
+            "fastqc_raw",
+            "fastqc_trimmed",
+            "samtools_stats",
+            "samtools_flagstat",
+            "picard_collect_multiple_metrics",
+            "qualimap_bamqc",
+            "multiqc",
+        ):
+            assert rule in result.stdout, f"Expected QC rule '{rule}' not in --list-rules output"

--- a/tests/test_dryrun.py
+++ b/tests/test_dryrun.py
@@ -98,7 +98,7 @@ class TestDryRun:
         assert result.returncode != 0
 
     def test_qc_rules_listed(self):
-        """QC rules should be listed when qc.enabled is true (default)."""
+        """QC rules should be listed when qc.enabled is true."""
         result = _run_snakemake("--list-rules", dry_run=False)
         assert result.returncode == 0, result.stderr
         for rule in (

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,6 +12,7 @@ import pytest
 # Add workflow/rules to path so we can import helpers directly
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "workflow" / "rules"))
 from helpers import (
+    get_all_basenames,
     get_basenames_for_sample,
     get_java_opts,
     get_samples,
@@ -93,6 +94,39 @@ class TestGetSamples:
         )
         result = get_samples(df)
         assert result == ["Alpha", "Zebra"]
+
+
+# ============================================================================
+# TestGetAllBasenames
+# ============================================================================
+
+
+class TestGetAllBasenames:
+    """Tests for get_all_basenames()."""
+
+    def test_returns_all_sorted(self, samples_df):
+        result = get_all_basenames(samples_df)
+        assert result == ["SampleA_S1_L001", "SampleA_S1_L002", "SampleB_S2_L001"]
+
+    def test_single_entry(self):
+        df = pd.DataFrame(
+            {
+                "fastq_files_basename": ["X_S1_L001"],
+                "project_sample": ["OnlySample"],
+            }
+        )
+        result = get_all_basenames(df)
+        assert result == ["X_S1_L001"]
+
+    def test_no_duplicates(self):
+        df = pd.DataFrame(
+            {
+                "fastq_files_basename": ["A_S1_L001", "A_S1_L001", "B_S2_L001"],
+                "project_sample": ["A", "A", "B"],
+            }
+        )
+        result = get_all_basenames(df)
+        assert result == ["A_S1_L001", "B_S2_L001"]
 
 
 # ============================================================================

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -92,6 +92,39 @@ class TestConfigSchema:
         cfg = _load_yaml(repo_config)
         snakemake_validate(cfg, str(SCHEMA_DIR / "config.schema.yaml"))
 
+    def test_qc_defaults_valid(self, valid_config):
+        """QC section is optional — config without it should pass."""
+        cfg = copy.deepcopy(valid_config)
+        cfg.pop("qc", None)
+        snakemake_validate(cfg, str(SCHEMA_DIR / "config.schema.yaml"))
+
+    def test_qc_all_flags(self, valid_config):
+        """QC section with all flags set should pass."""
+        cfg = copy.deepcopy(valid_config)
+        cfg["qc"] = {
+            "enabled": True,
+            "fastqc": True,
+            "samtools_stats": True,
+            "samtools_flagstat": True,
+            "picard_collect_metrics": True,
+            "qualimap": False,
+            "qualimap_feature_file": "",
+        }
+        snakemake_validate(cfg, str(SCHEMA_DIR / "config.schema.yaml"))
+
+    def test_qc_disabled(self, valid_config):
+        """QC disabled should pass."""
+        cfg = copy.deepcopy(valid_config)
+        cfg["qc"] = {"enabled": False}
+        snakemake_validate(cfg, str(SCHEMA_DIR / "config.schema.yaml"))
+
+    def test_qc_invalid_type(self, valid_config):
+        """String where boolean expected should fail."""
+        cfg = copy.deepcopy(valid_config)
+        cfg["qc"] = {"enabled": "yes"}
+        with pytest.raises(_SchemaError):
+            snakemake_validate(cfg, str(SCHEMA_DIR / "config.schema.yaml"))
+
 
 # ============================================================================
 # Samples schema tests

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -24,6 +24,7 @@ include: "rules/dedup.smk"
 include: "rules/bqsr.smk"
 include: "rules/trim.smk"
 include: "rules/utilities.smk"
+include: "rules/qc.smk"
 
 
 ALL_SAMPLES = get_samples()
@@ -35,3 +36,4 @@ rule all:
             os.path.join(BQSR_DIR, "{sample}" + FINAL_BAM_SUFFIX),
             sample=ALL_SAMPLES,
         ),
+        ([os.path.join(QC_DIR, "multiqc_report.html")] if QC_ENABLED else []),

--- a/workflow/envs/fastqc.yaml
+++ b/workflow/envs/fastqc.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - fastqc=0.12.1

--- a/workflow/envs/multiqc.yaml
+++ b/workflow/envs/multiqc.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - multiqc=1.33

--- a/workflow/envs/qualimap.yaml
+++ b/workflow/envs/qualimap.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - qualimap=2.3

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -3,6 +3,7 @@ import pandas as pd
 from rules.helpers import (
     get_java_opts as _get_java_opts_impl,
     get_samples as _get_samples_impl,
+    get_all_basenames as _get_all_basenames_impl,
     get_basenames_for_sample as _get_basenames_impl,
     resolve_fastq_path as _resolve_fastq_path_impl,
 )
@@ -50,6 +51,11 @@ MERGED_DIR = os.path.join(OUTPUT_DIR, "merged")
 DEDUP_DIR = os.path.join(OUTPUT_DIR, "dedup")
 BQSR_DIR = os.path.join(OUTPUT_DIR, "bqsr")
 
+# --- Quality control ---
+QC_CFG = config.get("qc", {})
+QC_ENABLED = QC_CFG.get("enabled", True)
+QC_DIR = os.path.join(OUTPUT_DIR, "qc")
+
 
 # =============================================================================
 # Samples metadata
@@ -62,6 +68,11 @@ samples_df = pd.read_table(config["paths"]["samples"]).set_index(
 def get_samples():
     """Return sorted list of unique sample names from metadata."""
     return _get_samples_impl(samples_df)
+
+
+def get_all_basenames():
+    """Return sorted list of all FASTQ basenames from metadata."""
+    return _get_all_basenames_impl(samples_df)
 
 
 def get_basenames_for_sample(sample):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -53,7 +53,7 @@ BQSR_DIR = os.path.join(OUTPUT_DIR, "bqsr")
 
 # --- Quality control ---
 QC_CFG = config.get("qc", {})
-QC_ENABLED = QC_CFG.get("enabled", True)
+QC_ENABLED = QC_CFG.get("enabled", False)
 QC_DIR = os.path.join(OUTPUT_DIR, "qc")
 
 

--- a/workflow/rules/helpers.py
+++ b/workflow/rules/helpers.py
@@ -37,6 +37,18 @@ def get_samples(samples_df) -> list[str]:
     return sorted(samples_df["project_sample"].unique().tolist())
 
 
+def get_all_basenames(samples_df) -> list[str]:
+    """Return sorted list of all FASTQ basenames from metadata.
+
+    Args:
+        samples_df: DataFrame with a 'fastq_files_basename' column.
+
+    Returns:
+        Sorted list of all FASTQ basenames.
+    """
+    return sorted(samples_df["fastq_files_basename"].unique().tolist())
+
+
 def get_basenames_for_sample(samples_df, sample: str) -> list[str]:
     """Return all FASTQ basenames belonging to a given sample.
 

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -25,12 +25,18 @@ _PICARD_PREFIX = os.path.join(PICARD_QC_DIR, "{sample}.multiple_metrics")
 
 # -----------------------------------------------------------------------------
 # FastQC helpers — build a lookup from output stem to source FASTQ path.
-# FastQC names outputs by stripping .fastq.gz from the input filename,
-# so we precompute exact output stems from the configured suffixes.
+# FastQC names outputs by stripping compression/FASTQ extensions from the
+# input filename, so we precompute exact output stems from the configured
+# suffixes.  Handle .fastq.gz, .fq.gz, .fastq, .fq (and bare .gz fallback).
 # -----------------------------------------------------------------------------
 def _fastqc_stem(suffix):
-    """Strip .fastq.gz to get the filename stem FastQC will use."""
-    return suffix.replace(".fastq.gz", "")
+    """Return the filename stem FastQC will use for a given FASTQ suffix."""
+    for ext in (".fastq.gz", ".fq.gz", ".fastq", ".fq"):
+        if suffix.endswith(ext):
+            return suffix[: -len(ext)]
+    if suffix.endswith(".gz"):
+        return suffix[: -len(".gz")]
+    return suffix
 
 
 _RAW_R1_STEM = _fastqc_stem(R1_SUFFIX)  # e.g. "_R1_001"
@@ -88,10 +94,20 @@ rule fastqc_raw:
 # =============================================================================
 # FastQC — trimmed FASTQs (only when trimming is enabled)
 # =============================================================================
+def _get_trimmed_fastq(wildcards):
+    """Resolve trimmed FASTQ path; raise a clear error when trimming is off."""
+    if not TRIMMING_ENABLED:
+        raise ValueError(
+            f"fastqc_trimmed requested for '{wildcards.fq_stem}' but "
+            "trimming.enabled is false in config.yaml"
+        )
+    return _FASTQC_TRIMMED_LOOKUP[wildcards.fq_stem]
+
+
 rule fastqc_trimmed:
     """Run FastQC on a trimmed FASTQ file."""
     input:
-        lambda wc: _FASTQC_TRIMMED_LOOKUP[wc.fq_stem],
+        _get_trimmed_fastq,
     output:
         html=os.path.join(FASTQC_TRIMMED_DIR, "{fq_stem}_fastqc.html"),
         zip=os.path.join(FASTQC_TRIMMED_DIR, "{fq_stem}_fastqc.zip"),

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -1,0 +1,337 @@
+# =============================================================================
+# workflow/rules/qc.smk — Quality control rules
+# =============================================================================
+# FastQC (raw + trimmed FASTQs), samtools stats/flagstat, Picard
+# CollectMultipleMetrics, Qualimap bamqc, and MultiQC aggregation.
+#
+# Controlled by the qc section in config.yaml:
+#   qc.enabled             — master switch (default: true)
+#   qc.fastqc              — FastQC on FASTQs (default: true)
+#   qc.samtools_stats      — samtools stats on final BAM (default: true)
+#   qc.samtools_flagstat   — samtools flagstat on final BAM (default: true)
+#   qc.picard_collect_metrics — Picard CollectMultipleMetrics (default: true)
+#   qc.qualimap            — Qualimap bamqc, opt-in (default: false)
+# =============================================================================
+
+FASTQC_RAW_DIR = os.path.join(QC_DIR, "fastqc", "raw")
+FASTQC_TRIMMED_DIR = os.path.join(QC_DIR, "fastqc", "trimmed")
+SAMTOOLS_QC_DIR = os.path.join(QC_DIR, "samtools")
+PICARD_QC_DIR = os.path.join(QC_DIR, "picard")
+QUALIMAP_QC_DIR = os.path.join(QC_DIR, "qualimap")
+
+# Picard CollectMultipleMetrics output prefix (contains {sample} wildcard)
+_PICARD_PREFIX = os.path.join(PICARD_QC_DIR, "{sample}.multiple_metrics")
+
+
+# -----------------------------------------------------------------------------
+# FastQC helpers — build a lookup from output stem to source FASTQ path.
+# FastQC names outputs by stripping .fastq.gz from the input filename,
+# so we precompute exact output stems from the configured suffixes.
+# -----------------------------------------------------------------------------
+def _fastqc_stem(suffix):
+    """Strip .fastq.gz to get the filename stem FastQC will use."""
+    return suffix.replace(".fastq.gz", "")
+
+
+_RAW_R1_STEM = _fastqc_stem(R1_SUFFIX)  # e.g. "_R1_001"
+_RAW_R2_STEM = _fastqc_stem(R2_SUFFIX)  # e.g. "_R2_001"
+_TRIM_R1_STEM = _fastqc_stem(TRIMMED_R1_SUFFIX)  # e.g. ".bbduk_R1_001"
+_TRIM_R2_STEM = _fastqc_stem(TRIMMED_R2_SUFFIX)  # e.g. ".bbduk_R2_001"
+
+# Maps: fq_stem -> source FASTQ path  (built at parse time)
+_FASTQC_RAW_LOOKUP: dict[str, str] = {}
+_FASTQC_TRIMMED_LOOKUP: dict[str, str] = {}
+
+for _bn in get_all_basenames():
+    _row = samples_df.loc[_bn]
+    _sub = _row.get("subfolder", "") if "subfolder" in samples_df.columns else ""
+    _raw_base = os.path.join(FASTQ_DIR, str(_sub)) if _sub else FASTQ_DIR
+
+    _FASTQC_RAW_LOOKUP[_bn + _RAW_R1_STEM] = os.path.join(_raw_base, _bn + R1_SUFFIX)
+    _FASTQC_RAW_LOOKUP[_bn + _RAW_R2_STEM] = os.path.join(_raw_base, _bn + R2_SUFFIX)
+
+    if TRIMMING_ENABLED:
+        _FASTQC_TRIMMED_LOOKUP[_bn + _TRIM_R1_STEM] = os.path.join(
+            TRIMMED_DIR, _bn + TRIMMED_R1_SUFFIX
+        )
+        _FASTQC_TRIMMED_LOOKUP[_bn + _TRIM_R2_STEM] = os.path.join(
+            TRIMMED_DIR, _bn + TRIMMED_R2_SUFFIX
+        )
+
+
+# =============================================================================
+# FastQC — raw FASTQs
+# =============================================================================
+rule fastqc_raw:
+    """Run FastQC on a raw FASTQ file."""
+    input:
+        lambda wc: _FASTQC_RAW_LOOKUP[wc.fq_stem],
+    output:
+        html=os.path.join(FASTQC_RAW_DIR, "{fq_stem}_fastqc.html"),
+        zip=os.path.join(FASTQC_RAW_DIR, "{fq_stem}_fastqc.zip"),
+    params:
+        outdir=FASTQC_RAW_DIR,
+    threads: 1
+    conda:
+        "../envs/fastqc.yaml"
+    log:
+        os.path.join(LOG_DIR, "fastqc.raw.{fq_stem}.log"),
+    shell:
+        r"""
+        fastqc --quiet --threads {threads} \
+            --outdir "{params.outdir}" \
+            "{input}" \
+            2> {log}
+        """
+
+
+# =============================================================================
+# FastQC — trimmed FASTQs (only when trimming is enabled)
+# =============================================================================
+rule fastqc_trimmed:
+    """Run FastQC on a trimmed FASTQ file."""
+    input:
+        lambda wc: _FASTQC_TRIMMED_LOOKUP[wc.fq_stem],
+    output:
+        html=os.path.join(FASTQC_TRIMMED_DIR, "{fq_stem}_fastqc.html"),
+        zip=os.path.join(FASTQC_TRIMMED_DIR, "{fq_stem}_fastqc.zip"),
+    params:
+        outdir=FASTQC_TRIMMED_DIR,
+    threads: 1
+    conda:
+        "../envs/fastqc.yaml"
+    log:
+        os.path.join(LOG_DIR, "fastqc.trimmed.{fq_stem}.log"),
+    shell:
+        r"""
+        fastqc --quiet --threads {threads} \
+            --outdir "{params.outdir}" \
+            "{input}" \
+            2> {log}
+        """
+
+
+# =============================================================================
+# samtools stats
+# =============================================================================
+rule samtools_stats:
+    """Compute alignment statistics on final BAM."""
+    input:
+        bam=os.path.join(BQSR_DIR, "{sample}" + FINAL_BAM_SUFFIX),
+    output:
+        os.path.join(SAMTOOLS_QC_DIR, "{sample}.stats.txt"),
+    threads: 1
+    conda:
+        "../envs/bwa_samtools.yaml"
+    log:
+        os.path.join(LOG_DIR, "samtools_stats.{sample}.log"),
+    shell:
+        r"""
+        samtools stats "{input.bam}" > {output} 2> {log}
+        """
+
+
+# =============================================================================
+# samtools flagstat
+# =============================================================================
+rule samtools_flagstat:
+    """Compute flag-based read counts on final BAM."""
+    input:
+        bam=os.path.join(BQSR_DIR, "{sample}" + FINAL_BAM_SUFFIX),
+    output:
+        os.path.join(SAMTOOLS_QC_DIR, "{sample}.flagstat.txt"),
+    threads: 1
+    conda:
+        "../envs/bwa_samtools.yaml"
+    log:
+        os.path.join(LOG_DIR, "samtools_flagstat.{sample}.log"),
+    shell:
+        r"""
+        samtools flagstat "{input.bam}" > {output} 2> {log}
+        """
+
+
+# =============================================================================
+# Picard CollectMultipleMetrics (via GATK4)
+# =============================================================================
+rule picard_collect_multiple_metrics:
+    """Collect comprehensive alignment QC metrics in a single pass."""
+    input:
+        bam=os.path.join(BQSR_DIR, "{sample}" + FINAL_BAM_SUFFIX),
+    output:
+        multiext(
+            _PICARD_PREFIX,
+            ".alignment_summary_metrics",
+            ".insert_size_metrics",
+            ".insert_size_histogram.pdf",
+            ".quality_distribution_metrics",
+            ".quality_distribution.pdf",
+            ".quality_by_cycle_metrics",
+            ".quality_by_cycle.pdf",
+            ".base_distribution_by_cycle_metrics",
+            ".base_distribution_by_cycle.pdf",
+            ".gc_bias.detail_metrics",
+            ".gc_bias.summary_metrics",
+            ".gc_bias.pdf",
+            ".bait_bias_detail_metrics",
+            ".bait_bias_summary_metrics",
+            ".error_summary_metrics",
+            ".pre_adapter_detail_metrics",
+            ".pre_adapter_summary_metrics",
+            ".quality_yield_metrics",
+        ),
+    params:
+        java_opts=get_java_opts,
+        reference=REF,
+        output_prefix=_PICARD_PREFIX,
+        extra=config.get("params", {}).get("gatk", {}).get("CollectMultipleMetrics", ""),
+    threads: 1
+    conda:
+        "../envs/gatk.yaml"
+    log:
+        os.path.join(LOG_DIR, "picard_collect_metrics.{sample}.log"),
+    shell:
+        r"""
+        gatk --java-options '{params.java_opts}' CollectMultipleMetrics \
+            {params.extra} \
+            -I "{input.bam}" \
+            -R "{params.reference}" \
+            -O "{params.output_prefix}" \
+            --PROGRAM CollectAlignmentSummaryMetrics \
+            --PROGRAM CollectInsertSizeMetrics \
+            --PROGRAM QualityScoreDistribution \
+            --PROGRAM MeanQualityByCycle \
+            --PROGRAM CollectBaseDistributionByCycle \
+            --PROGRAM CollectGcBiasMetrics \
+            --PROGRAM CollectSequencingArtifactMetrics \
+            --PROGRAM CollectQualityYieldMetrics \
+            2> {log}
+        """
+
+
+# =============================================================================
+# Qualimap bamqc (opt-in)
+# =============================================================================
+rule qualimap_bamqc:
+    """Run Qualimap bamqc for coverage and alignment quality analysis."""
+    input:
+        bam=os.path.join(BQSR_DIR, "{sample}" + FINAL_BAM_SUFFIX),
+    output:
+        directory(os.path.join(QUALIMAP_QC_DIR, "{sample}")),
+    params:
+        feature_file=(
+            f'--feature-file "{QC_CFG.get("qualimap_feature_file")}"'
+            if QC_CFG.get("qualimap_feature_file")
+            else ""
+        ),
+    threads: 4
+    conda:
+        "../envs/qualimap.yaml"
+    log:
+        os.path.join(LOG_DIR, "qualimap.{sample}.log"),
+    shell:
+        r"""
+        qualimap bamqc \
+            -bam "{input.bam}" \
+            -outdir "{output}" \
+            --java-mem-size={resources.mem_mb}M \
+            -nt {threads} \
+            {params.feature_file} \
+            2> {log}
+        """
+
+
+# =============================================================================
+# MultiQC — aggregate all QC outputs into a single report
+# =============================================================================
+def _collect_multiqc_inputs(wildcards):
+    """Build the list of QC outputs to aggregate based on config flags."""
+    inputs = []
+    all_basenames = get_all_basenames()
+    all_samples = get_samples()
+
+    if QC_CFG.get("fastqc", True):
+        for bn in all_basenames:
+            for stem_suffix in [_RAW_R1_STEM, _RAW_R2_STEM]:
+                inputs.append(os.path.join(FASTQC_RAW_DIR, f"{bn}{stem_suffix}_fastqc.zip"))
+            if TRIMMING_ENABLED:
+                for stem_suffix in [_TRIM_R1_STEM, _TRIM_R2_STEM]:
+                    inputs.append(
+                        os.path.join(
+                            FASTQC_TRIMMED_DIR,
+                            f"{bn}{stem_suffix}_fastqc.zip",
+                        )
+                    )
+
+    if QC_CFG.get("samtools_stats", True):
+        inputs.extend(
+            expand(
+                os.path.join(SAMTOOLS_QC_DIR, "{sample}.stats.txt"),
+                sample=all_samples,
+            )
+        )
+
+    if QC_CFG.get("samtools_flagstat", True):
+        inputs.extend(
+            expand(
+                os.path.join(SAMTOOLS_QC_DIR, "{sample}.flagstat.txt"),
+                sample=all_samples,
+            )
+        )
+
+    if QC_CFG.get("picard_collect_metrics", True):
+        inputs.extend(
+            expand(
+                os.path.join(
+                    PICARD_QC_DIR,
+                    "{sample}.multiple_metrics.alignment_summary_metrics",
+                ),
+                sample=all_samples,
+            )
+        )
+
+    # Always include MarkDuplicates metrics (produced by dedup rule)
+    inputs.extend(
+        expand(
+            os.path.join(DEDUP_DIR, "{sample}" + DEDUP_METRICS_SUFFIX),
+            sample=all_samples,
+        )
+    )
+
+    if QC_CFG.get("qualimap", False):
+        inputs.extend(
+            expand(
+                os.path.join(QUALIMAP_QC_DIR, "{sample}"),
+                sample=all_samples,
+            )
+        )
+
+    return inputs
+
+
+rule multiqc:
+    """Aggregate all QC outputs into a single MultiQC report."""
+    input:
+        _collect_multiqc_inputs,
+    output:
+        report=os.path.join(QC_DIR, "multiqc_report.html"),
+        data=directory(os.path.join(QC_DIR, "multiqc_data")),
+    params:
+        outdir=QC_DIR,
+        search_dirs=lambda wc: f'"{QC_DIR}" "{DEDUP_DIR}"',
+        extra=config.get("params", {}).get("multiqc", {}).get("extra", ""),
+    threads: 1
+    conda:
+        "../envs/multiqc.yaml"
+    log:
+        os.path.join(LOG_DIR, "multiqc.log"),
+    shell:
+        r"""
+        multiqc \
+            --force \
+            --outdir "{params.outdir}" \
+            --filename multiqc_report.html \
+            {params.extra} \
+            {params.search_dirs} \
+            2> {log}
+        """

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -180,6 +180,38 @@ properties:
         type: string
         default: "0,10,20,30,40,50,60"
 
+  qc:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        default: true
+        description: Master switch for all QC rules
+      fastqc:
+        type: boolean
+        default: true
+        description: Run FastQC on raw (and trimmed) FASTQs
+      samtools_stats:
+        type: boolean
+        default: true
+        description: Run samtools stats on final BAM
+      samtools_flagstat:
+        type: boolean
+        default: true
+        description: Run samtools flagstat on final BAM
+      picard_collect_metrics:
+        type: boolean
+        default: true
+        description: Run Picard CollectMultipleMetrics on final BAM
+      qualimap:
+        type: boolean
+        default: false
+        description: Run Qualimap bamqc (opt-in, high memory on GRCh38)
+      qualimap_feature_file:
+        type: string
+        default: ""
+        description: BED file for Qualimap exome on-target stats
+
   subset:
     type: object
     properties:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -185,7 +185,7 @@ properties:
     properties:
       enabled:
         type: boolean
-        default: true
+        default: false
         description: Master switch for all QC rules
       fastqc:
         type: boolean


### PR DESCRIPTION
## Summary

- Add end-to-end quality control via `workflow/rules/qc.smk` with 7 rules: FastQC (raw + trimmed FASTQs), samtools stats, samtools flagstat, Picard CollectMultipleMetrics (8 collectors), Qualimap bamqc (opt-in), and MultiQC aggregation
- Config-driven with `qc.enabled` master switch and per-tool toggles — fully backward-compatible when disabled
- Reuses existing conda envs for samtools (`bwa_samtools.yaml`) and Picard (`gatk.yaml`); adds 3 new envs (fastqc, multiqc, qualimap)
- Profile resource allocations for all QC rules; Qualimap defaults to 16 GB (opt-in due to GRCh38 memory)
- MultiQC also picks up existing MarkDuplicates metrics and BBDuk logs automatically

Closes #7, #17, #6

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes
- [x] `snakefmt --check` passes
- [x] `pytest -m "not dryrun"` — 92 passed (new: `TestGetAllBasenames`, QC schema tests, QC dry-run test)
- [ ] CI passes on this PR
- [ ] Mermaid diagram renders correctly in PR preview